### PR TITLE
delete useless lines in benchmarks/benchmark_sliding_tile_attention.py

### DIFF
--- a/benchmarks/benchmark_sliding_tile_attention.py
+++ b/benchmarks/benchmark_sliding_tile_attention.py
@@ -2,7 +2,6 @@ import torch
 from benchmark_common_utils import Benchmark
 
 import attention_gym
-from tests.sta_flex_attention import sta_flex_attention
 
 
 class AttentionBenchmark(Benchmark):


### PR DESCRIPTION
delete 'from tests.sta_flex_attention import sta_flex_attention' in benchmarks/benchmark_sliding_tile_attention.py